### PR TITLE
Fix creation of numpy array from inhomogeneous lists in _compile_grad_data

### DIFF
--- a/flocra_pulseq/interpreter.py
+++ b/flocra_pulseq/interpreter.py
@@ -371,8 +371,8 @@ class PSInterpreter:
                                 x_ip.append(shape_x[i])
                         # grad = shape * grad_event['amp']
                         # x = self._shapes[grad_event['time_shape_id']] * self._definitions['GradientRasterTime'] * 1e6
-                        grad = np.hstack(np.array(grad_ip)) * grad_event['amp']
-                        x = np.hstack(np.array(x_ip)) * self._definitions['GradientRasterTime'] * 1e6
+                        grad = np.hstack([np.array(item).flatten() for item in grad_ip]) * grad_event['amp']
+                        x = np.hstack([np.array(item).flatten() for item in x_ip]) * self._definitions['GradientRasterTime'] * 1e6
                 else:
                     # Event length and duration, create time points
                     shape = self._shapes[grad_event['shape_id']]


### PR DESCRIPTION
In lines 374 and 375, the creation of the `grad` and `x` NumPy array fails because `grad_ip` and `x_ip` are inhomogeneous lists. This can be resolved with the following fix.

I tested with sequence from Maxim and it looks to work.